### PR TITLE
Ubuntu 18 build fix

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,7 +9,7 @@
 	url = https://github.com/jbeder/yaml-cpp
 [submodule "external/cturtle"]
 	path = external/cturtle
-	url = https://github.com/larryk85/cturtle
+	url = https://github.com/dimas1185/cturtle
 [submodule "external/Mustache"]
 	path = external/Mustache
 	url = https://github.com/kainjow/Mustache


### PR DESCRIPTION
This is to address cdt build failure on Ubuntu 18 when adding antler-proj as a submodule