### PR TITLE
fix for parsing error handling of an empty command argument

### DIFF
--- a/tools/main.cpp
+++ b/tools/main.cpp
@@ -74,7 +74,8 @@ int main(int argc, char** argv) {
       app.parse(argc, argv);
    }
    // This hack fix parsing error handling of an empty command argument. Example: antler-proj build ~/path/proj ""
-   catch (CLI::ExtrasError& e) {
+   catch (const CLI::ExtrasError& e) {
+
       std::string error_message(e.what());
       CLI::detail::trim(error_message);
 

--- a/tools/main.cpp
+++ b/tools/main.cpp
@@ -57,7 +57,7 @@ int main(int argc, char** argv) {
    app.add_flag_callback("-V,--version",
          [&app]() {
             std::cout << app.get_name() << " v" << antler::system::version::full() << std::endl;
-            std::exit(0);       // Succesfull exit MUST happen here.
+            std::exit(0);       // Successful exit MUST happen here.
          },
          "get the version of antler-proj");
 
@@ -70,7 +70,18 @@ int main(int argc, char** argv) {
           antler::update_project,
           antler::validate_project> runner{app};
 
-   CLI11_PARSE(app, argc, argv);
+   try {
+      app.parse(argc, argv);
+   }
+   // This hack fix parsing error handling of an empty command argument. Example: antler-proj build ~/path/proj ""
+   catch (CLI::ExtrasError &e) {
+      if (std::string_view{"The following argument was not expected: "} == e.what()) {
+         return app.exit(CLI::ExtrasError("Empty argument is encountered in the command line", e.get_exit_code()));
+      }
+   }
+   catch (const CLI::ParseError &e) {
+      return app.exit(e);
+   }
 
    try {
       return runner.exec();

--- a/tools/main.cpp
+++ b/tools/main.cpp
@@ -74,7 +74,7 @@ int main(int argc, char** argv) {
       app.parse(argc, argv);
    }
    // This hack fix parsing error handling of an empty command argument. Example: antler-proj build ~/path/proj ""
-   catch (CLI::ExtrasError &e) {
+   catch (CLI::ExtrasError& e) {
       std::string error_message(e.what());
       CLI::detail::trim(error_message);
 


### PR DESCRIPTION
Example: antler-proj build ~/path/proj ""
corresponding to issue #19 