### PR TITLE
Optional arguments should be in square brackets, required arguments should be in angle brackets.

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -9,6 +9,7 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/constants.hpp.in
 
 add_executable(unit_tests
                main.cpp
+               bnfformatter_tests.cpp
                cmake_tests.cpp
                dependency_tests.cpp
                location_tests.cpp

--- a/tests/bnfformatter_tests.cpp
+++ b/tests/bnfformatter_tests.cpp
@@ -1,0 +1,19 @@
+/// @copyright See `LICENSE` in the root directory of this project.
+
+#include "../tools/bnfformatter.hpp"
+
+#include <catch2/catch.hpp>
+
+TEST_CASE("bnfformatter_make_option_opts") {
+   using namespace CLI;
+
+   App app;
+   std::string var1, var2;
+   const auto* opt1 = app.add_option("opt1", var1, "desc1")->required();
+   const auto* opt2 = app.add_option("opt2", var2, "desc2")->default_val("0.0.0");;
+   
+   BnfFormatter bnfFormatter;
+
+   CHECK(bnfFormatter.make_option_opts(opt1) == " <TEXT>");
+   CHECK(bnfFormatter.make_option_opts(opt2) == " [TEXT], default: 0.0.0");
+}

--- a/tools/bnfformatter.hpp
+++ b/tools/bnfformatter.hpp
@@ -1,0 +1,43 @@
+#pragma once
+
+#include "CLI11.hpp"
+
+class BnfFormatter : public CLI::Formatter {
+  public:
+    std::string make_option_opts(const CLI::Option* opt) const override;
+};
+
+std::string BnfFormatter::make_option_opts(const CLI::Option* opt) const {
+    std::stringstream out;
+
+    if(!opt->get_option_text().empty()) {
+        out << " " << opt->get_option_text();
+    } else {
+        if(opt->get_type_size() != 0) {
+            if(!opt->get_type_name().empty()) {
+                out << " " << (opt->get_required() ? "<" : "[");
+                out << get_label(opt->get_type_name());
+                out << (opt->get_required() ? ">" : "]");
+            }
+            if(!opt->get_default_str().empty())
+                out << ", default: " << opt->get_default_str();
+            if(opt->get_expected_max() == CLI::detail::expected_max_vector_size)
+                out << " ...";
+            else if(opt->get_expected_min() > 1)
+                out << " x " << opt->get_expected();
+        }
+        if(!opt->get_envname().empty())
+            out << " (" << get_label("Env") << ":" << opt->get_envname() << ")";
+        if(!opt->get_needs().empty()) {
+            out << " " << get_label("Needs") << ":";
+            for(const auto* op : opt->get_needs())
+                out << " " << op->get_name();
+        }
+        if(!opt->get_excludes().empty()) {
+            out << " " << get_label("Excludes") << ":";
+            for(const auto* op : opt->get_excludes())
+                out << " " << op->get_name();
+        }
+    }
+    return out.str();
+}

--- a/tools/main.cpp
+++ b/tools/main.cpp
@@ -4,11 +4,10 @@
 #include <string>
 #include <string_view>
 #include <memory>
-#include <vector>
 #include <optional>
 #include <tuple>
 
-#include "CLI11.hpp"
+#include "bnfformatter.hpp"
 
 #include "add_to.hpp"
 #include "build.hpp"
@@ -26,7 +25,7 @@ static V depends(V&& v) { return std::forward<V>(v); }
 
 template <typename... Ts>
 struct runner {
-   runner(CLI::App& app)
+   explicit runner(CLI::App& app)
       : tup(depends<Ts>(app)...) {}
 
    template <std::size_t I=0>
@@ -61,7 +60,8 @@ int main(int argc, char** argv) {
          },
          "get the version of antler-proj");
 
-
+   app.formatter(std::make_shared<BnfFormatter>());
+   
    runner<antler::add_to_project,
           antler::build_project,
           antler::init_project,

--- a/tools/remove_from.hpp
+++ b/tools/remove_from.hpp
@@ -66,7 +66,7 @@ namespace antler {
 
       remove_from_project(CLI::App& app) {
          path = system::fs::current_path().string();
-         subcommand = app.add_subcommand("remove", "Add an app, dependency, library or test to your project.");
+         subcommand = app.add_subcommand("remove", "Remove an app, dependency, library or test from your project.");
          subcommand->add_option("-p, path", path, "Path containing the project's yaml file.");
 
          app_subcommand = subcommand->add_subcommand("app", "Remove app from the project.");
@@ -79,7 +79,7 @@ namespace antler {
          lib_subcommand->footer(std::string(R"(Examples:)")
                + "\n\t" + app.get_name() +R"( remove lib MyLib)");
          lib_subcommand->add_option("-p, path", path, "Path containing the project's yaml file.");
-         lib_subcommand->add_option("-n, name", obj_name, "The name of the library to add.")->required();
+         lib_subcommand->add_option("-n, name", obj_name, "The name of the library to remove.")->required();
 
          dep_subcommand = subcommand->add_subcommand("dep", "Remove a dependency from the project.");
          dep_subcommand->footer(std::string(R"(Examples:)")

--- a/tools/update.hpp
+++ b/tools/update.hpp
@@ -109,7 +109,7 @@ namespace antler {
 
       update_project(CLI::App& app) {
          path = system::fs::current_path().string();
-         subcommand = app.add_subcommand("update", "Update an app, dependency, library or test to your project.");
+         subcommand = app.add_subcommand("update", "Update an app, dependency, library or test of your project.");
          subcommand->add_option("-p, path", path, "Path containing the project's yaml file.");
 
          app_subcommand = subcommand->add_subcommand("app", "Update an app in the project.");


### PR DESCRIPTION
Resolves #14 

Modify formatter: optional arguments should be in square brackets, required arguments should be in angle brackets.
Fixed help for `remove`. 

Example help for `init`:
```
$ ./antler-proj init --help
Initialize a new project creating the directory tree and a `project.yaml` file.
Usage: antler-proj init [OPTIONS] path project_name [version]

Positionals:
  path <TEXT>                 The root path to create the project in.
  project_name <TEXT>         The name of the project.
  version [TEXT], default: 0.0.0
                              The version to store in the project file.

Options:
  -h,--help                   Print this help message and exit
  -p <TEXT>                   The root path to create the project in.
  -n <TEXT>                   The name of the project.
  -v [TEXT], default: 0.0.0   The version to store in the project file.

Examples:
	antler-proj init MyProjectName 1.0.0
```