### PR TITLE
When running `antler-proj` without arguments help will be displayed

### DIFF
--- a/tools/main.cpp
+++ b/tools/main.cpp
@@ -26,13 +26,15 @@ static V depends(V&& v) { return std::forward<V>(v); }
 
 template <typename... Ts>
 struct runner {
-   runner(CLI::App& app)
+   explicit runner(CLI::App& app)
       : tup(depends<Ts>(app)...), _app(app) {}
 
    template <std::size_t I=0>
    constexpr inline int exec() {
       if constexpr (I == sizeof...(Ts)) {
-         std::cout << _app.help();
+         std::cout << _app.help() << std::endl
+                   << "Please run one of the subcommands with --help option to get detailed help. "
+                   << "Example: antler-proj init --help" << std::endl;
          return 0;
       } else {
          if (*std::get<I>(tup).subcommand) {

--- a/tools/main.cpp
+++ b/tools/main.cpp
@@ -34,7 +34,7 @@ struct runner {
          std::cout << _app.help() << std::endl
                    << "Please run one of the subcommands with --help option to get detailed help. "
                    << "Example: antler-proj init --help" << std::endl;
-         return 0;
+         return 1;
       } else {
          if (*std::get<I>(tup).subcommand) {
             return std::get<I>(tup).exec();

--- a/tools/main.cpp
+++ b/tools/main.cpp
@@ -27,13 +27,13 @@ static V depends(V&& v) { return std::forward<V>(v); }
 template <typename... Ts>
 struct runner {
    runner(CLI::App& app)
-      : tup(depends<Ts>(app)...) {}
+      : tup(depends<Ts>(app)...), _app(app) {}
 
    template <std::size_t I=0>
    constexpr inline int exec() {
       if constexpr (I == sizeof...(Ts)) {
-         std::cerr << "Please run one of the subcommands available. Use --help to see what is available." << std::endl;
-         return -1;
+         std::cout << _app.help();
+         return 0;
       } else {
          if (*std::get<I>(tup).subcommand) {
             return std::get<I>(tup).exec();
@@ -44,6 +44,9 @@ struct runner {
 
    }
    std::tuple<Ts...> tup;
+
+   private:
+      const CLI::App& _app;
 };
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
Resolves #20 

Before:
```
$ antler-proj
Please run one of the subcommands available. Use --help to see what is available.
```

After:
```
$ ./antler-proj 
Antelope Smart Contract Project Management Tool
Usage: antler-proj [OPTIONS] [SUBCOMMAND]

Options:
  -h,--help                   Print this help message and exit
  -V,--version                get the version of antler-proj

Subcommands:
  validate                    Validate a project.
  update                      Update an app, dependency, library or test to your project.
  remove                      Add an app, dependency, library or test to your project.
  populate                    Populate a project's dependencies and CMake.
  init                        Initialize a new project creating the directory tree and a `project.yaml` file.
  build                       Build a project.
  add                         Add an app, dependency, library or test to your project.

Please run one of the subcommands with --help option to get detailed help. Example: antler-proj init --help
```