### PR TITLE
Add .py as text to gitattributes.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -13,3 +13,4 @@
 *.cpp text eol=lf
 *.patch text eol=lf
 *.in text eol=lf
+*.py text eol=lf


### PR DESCRIPTION
Missed this in the prior PR. Part of issue #55.