### PR TITLE
Return only positive error codes to shell. Fix clang-tidy warnings.

### DIFF
--- a/include/antler/project/version.hpp
+++ b/include/antler/project/version.hpp
@@ -24,7 +24,7 @@ public:
    using self = version;        ///< Alias for self type.
 
    /// @param ver  A string to create this version with.
-   inline version(std::string_view ver) {
+   explicit inline version(std::string_view ver) {
       system::info_log("project.version {0}", ver);
       ANTLER_CHECK(parse(ver) >= 0, "version malformed");
    }
@@ -33,7 +33,7 @@ public:
    /// @param min  Minor version component.
    /// @param pat  Patch version component.
    /// @param tweak  Tweak version component.
-   inline version(uint16_t maj=0, uint16_t min=0, uint16_t pat=0, std::string tweak="")
+   explicit inline version(uint16_t maj=0, uint16_t min=0, uint16_t pat=0, std::string tweak="")
       : major_comp(maj), minor_comp(min), patch_comp(pat), tweak_comp(std::move(tweak)) {}
 
    /// Copy constructor.
@@ -97,7 +97,7 @@ public:
 
       if (s[0] >= '0' && s[0] <= '9') {
          c = std::atoi(s.data());
-         consumed += c == 0 ? 1 : std::log10(c) + 1; ///< get the # of digits
+         consumed += c == 0 ? 1 : static_cast<int64_t>(std::log10(c) + 1); ///< get the # of digits
       } else {
          system::error_log("invalid version component : {0}", s);
          throw std::runtime_error("invalid version component");
@@ -200,7 +200,7 @@ public:
 
    /// Deserialization function from yaml node to version
    [[nodiscard]] inline bool from_yaml(const yaml::node_t& n) noexcept {
-      std::string s = n.as<std::string>();
+      auto s = n.as<std::string>();
       return parse({s.c_str(), s.size()}) > 0;
    }
 
@@ -208,7 +208,7 @@ private:
    uint16_t major_comp = 0;
    uint16_t minor_comp = 0;
    uint16_t patch_comp = 0;
-   std::string tweak_comp = "";
+   std::string tweak_comp;
 };
 
    // these don't need to be in global namespace ADL will handle finding the right one

--- a/include/antler/system/utils.hpp
+++ b/include/antler/system/utils.hpp
@@ -9,6 +9,7 @@
 #include <unordered_set>
 #include <vector>
 #include <regex>
+#include <sysexits.h>
 
 #include <bluegrass/cturtle.hpp>
 
@@ -106,7 +107,7 @@ namespace antler::system {
       FILE* h = popen(cmd.c_str(), "r");
       if (h == nullptr) {
          system::error_log("internal failure, program {0} not found.", prog);
-         return -1;
+         return EX_SOFTWARE;
       }
 
       constexpr size_t array_size = 64;

--- a/tests/common.hpp
+++ b/tests/common.hpp
@@ -43,7 +43,7 @@ static antler::project::project create_project() {
 
    project proj;
    proj.name("test_proj");
-   proj.version({1, 3, 4});
+   proj.version(version{1, 3, 4});
 
    proj.upsert(std::move(apps[0]));
    proj.upsert(std::move(libs[0]));

--- a/tests/project_tests.cpp
+++ b/tests/project_tests.cpp
@@ -30,7 +30,7 @@ TEST_CASE("Testing project") {
 
    project proj;
    proj.name("test_proj");
-   proj.version({1, 3, 4});
+   proj.version(version{1, 3, 4});
 
    proj.upsert(std::move(apps[0]));
    proj.upsert(std::move(libs[0]));

--- a/tests/version_tests.cpp
+++ b/tests/version_tests.cpp
@@ -172,8 +172,8 @@ TEST_CASE("Testing version class comparisons") {
 TEST_CASE("Testing version yaml conversions") {
    using namespace antler::project;
 
-   version v1 = {"v1.2.3"};
-   version v2 = {"2.3.4"};
+   version v1 = version{"v1.2.3"};
+   version v2 = version{"2.3.4"};
 
    yaml::node_t n1 = v1.to_yaml();
    yaml::node_t n2 = v2.to_yaml();

--- a/tools/add_to.hpp
+++ b/tools/add_to.hpp
@@ -214,7 +214,7 @@ namespace antler {
          */
          } else {
             system::error_log("Need to supply either dep/app/lib/test after `add`");
-            return -1;
+            return EX_USAGE;
          }
 
          proj.sync();

--- a/tools/init.hpp
+++ b/tools/init.hpp
@@ -2,6 +2,7 @@
 
 #include <iostream>
 #include <string>
+#include <sysexits.h>
 
 #include "CLI11.hpp"
 
@@ -25,7 +26,7 @@ namespace antler {
          antler::project::project proj = {path, name, version};
 
          if (!proj.init_dirs(path))
-            return -1;
+            return EX_CANTCREAT;
 
          proj.sync();
 

--- a/tools/main.cpp
+++ b/tools/main.cpp
@@ -3,9 +3,10 @@
 #include <iostream>
 #include <string>
 #include <string_view>
-#include <memory>
 #include <optional>
 #include <tuple>
+#include <sysexits.h>
+#include <cstdlib>
 
 #include "CLI11.hpp"
 
@@ -34,7 +35,7 @@ struct runner {
          std::cout << _app.help() << std::endl
                    << "Please run one of the subcommands with --help option to get detailed help. "
                    << "Example: antler-proj init --help" << std::endl;
-         return 1;
+         return EX_USAGE;
       } else {
          if (*std::get<I>(tup).subcommand) {
             return std::get<I>(tup).exec();
@@ -99,9 +100,9 @@ int main(int argc, char** argv) {
       return runner.exec();
    } catch(const std::exception& ex) {
       antler::system::error_log("{}", ex.what());
-      return -1;
+      return EXIT_FAILURE;
    } catch(...) {
       antler::system::error_log("unhandled exception");
-      return -2;
+      return EXIT_FAILURE;
    }
 }

--- a/tools/remove_from.hpp
+++ b/tools/remove_from.hpp
@@ -2,6 +2,7 @@
 
 #include <iostream>
 #include <string>
+#include <sysexits.h>
 
 #include "CLI11.hpp"
 
@@ -31,7 +32,7 @@ namespace antler {
       // TODO reenable remove_test() when test code is completed.
       //inline bool remove_test(antler::project::project& proj) { return remove_obj<antler::project::test_t>(proj); }
 
-      bool remove_dependency_from_all(antler::project::project& proj) {
+      bool remove_dependency_from_all(antler::project::project& proj) const {
          const auto& remove_dep = [](auto dep, auto& objs) {
             for (auto& [k, o] : objs) {
                if (o.remove_dependency(dep)) {
@@ -45,7 +46,7 @@ namespace antler {
          // TODO reenable call to remove_dep() when test code is completed.
          //remove_dep(dep_name, proj.tests());
 
-         return 0;
+         return false;
       }
 
       template <typename Obj>
@@ -64,7 +65,7 @@ namespace antler {
          return true;
       }
 
-      remove_from_project(CLI::App& app) {
+      explicit remove_from_project(CLI::App& app) {
          subcommand = app.add_subcommand("remove", "Remove an app, dependency, library or test from your project.");
          subcommand->add_option("-p,--path", path, "Path containing the project's yaml file.")->default_val(".");
 
@@ -117,7 +118,7 @@ namespace antler {
          */
          } else {
             system::error_log("Need to supply either dep/app/lib/test after remove");
-            return -1;
+            return EX_USAGE;
          }
 
          proj.sync();

--- a/tools/update.hpp
+++ b/tools/update.hpp
@@ -109,7 +109,7 @@ namespace antler {
          //update_dep(dep_name, proj.tests());
       }
 
-      update_project(CLI::App& app) {
+      explicit update_project(CLI::App& app) {
          subcommand = app.add_subcommand("update", "Update an app, dependency, library or test in your project.");
 
          subcommand->add_option("-p,--path", path, "Path containing the project's yaml file.")->default_val(".");
@@ -177,7 +177,7 @@ namespace antler {
          */
          } else {
             system::error_log("Need to supply either a dep/app/lib/test after `update`");
-            return -1;
+            return EX_USAGE;
          }
 
          proj.sync();
@@ -189,15 +189,15 @@ namespace antler {
       CLI::App*   dep_subcommand = nullptr;
       CLI::App*   lib_subcommand = nullptr;
       CLI::App*   test_subcommand = nullptr;
-      std::string path = "";
-      std::string obj_name = "";
-      std::string dep_name = "";
-      std::string lang = "";
-      std::string copts = "";
-      std::string lopts = "";
-      std::string loc = "";
-      std::string tag = "";
-      std::string release = "";
-      std::string digest = "";
+      std::string path;
+      std::string obj_name;
+      std::string dep_name;
+      std::string lang;
+      std::string copts;
+      std::string lopts;
+      std::string loc;
+      std::string tag;
+      std::string release;
+      std::string digest;
    };
 } // namespace antler

--- a/tools/validate.hpp
+++ b/tools/validate.hpp
@@ -30,7 +30,7 @@ namespace antler {
 
          if (!proj.has_valid_dependencies()) {
             system::error_log("The project contains invalid dependencies");
-            return -1;
+            return EXIT_FAILURE;
          }
 
          system::info_log("Valid project dependencies and all are reachable");


### PR DESCRIPTION
Resolves #57 

When I was modifying files, I cleaned them from clang-tidy warnings.